### PR TITLE
Data Service Refactor

### DIFF
--- a/models/reminder.js
+++ b/models/reminder.js
@@ -1,4 +1,7 @@
 'use strict';
+
+var moment = require('moment');
+
 module.exports = function(sequelize, DataTypes) {
   var Reminder = sequelize.define('Reminder', {
     timeframe: {
@@ -7,7 +10,10 @@ module.exports = function(sequelize, DataTypes) {
     },
     dueDate: {
       allowNull: false,
-      type: DataTypes.DATE
+      type: DataTypes.DATE,
+      get: function() {
+        return moment.utc(this.getDataValue('dueDate')).format('YYYY-MM-DD');
+      }
     },
     isSent: {
       allowNull: false,

--- a/models/school.js
+++ b/models/school.js
@@ -1,4 +1,7 @@
 'use strict';
+
+var moment = require('moment');
+
 module.exports = function(sequelize, DataTypes) {
   var School = sequelize.define('School', {
     name: {
@@ -7,7 +10,10 @@ module.exports = function(sequelize, DataTypes) {
     },
     dueDate: {
       allowNull: false,
-      type: DataTypes.DATE
+      type: DataTypes.DATE,
+      get: function() {
+        return moment.utc(this.getDataValue('dueDate')).format('YYYY-MM-DD');
+      }
     },
     isActive: {
       allowNull: false,

--- a/models/testdates.js
+++ b/models/testdates.js
@@ -1,13 +1,22 @@
 'use strict';
+
+var moment = require('moment');
+
 module.exports = function(sequelize, DataTypes) {
   var TestDate = sequelize.define('TestDate', {
     registrationDate: {
       allowNull: false,
-      type: DataTypes.DATE
+      type: DataTypes.DATE,
+      get: function() {
+        return moment.utc(this.getDataValue('registrationDate')).format('YYYY-MM-DD');
+      }
     },
     adminDate: {
       allowNull: false,
-      type: DataTypes.DATE
+      type: DataTypes.DATE,
+      get: function() {
+        return moment.utc(this.getDataValue('adminDate')).format('YYYY-MM-DD');
+      }
     }
   }, {
     classMethods: {

--- a/models/user.js
+++ b/models/user.js
@@ -1,9 +1,20 @@
 'use strict';
+var cipher = require('../services/cipherService');
+
 module.exports = function(sequelize, DataTypes) {
   var User = sequelize.define('User', {
     phoneNumber: {
       type: DataTypes.STRING,
-      unique: true
+      unique: true,
+      set: function(phoneNumber) {
+        var encryptedPhoneNumber = cipher.encrypt(phoneNumber);
+        this.setDataValue('phoneNumber', encryptedPhoneNumber);
+      },
+      get: function() {
+        var encryptedPhoneNumber = this.getDataValue('phoneNumber');
+        var phoneNumber = cipher.decrypt(encryptedPhoneNumber);
+        return phoneNumber;
+      }
     },
     confirmCode: DataTypes.STRING,
     confirmCodeTimestamp: DataTypes.DATE,

--- a/services/adminUserService.js
+++ b/services/adminUserService.js
@@ -15,7 +15,7 @@ module.exports = function(models) {
     };
 
     return AdminUser.create(data).then(function(newUser) {
-      return newUser.dataValues;
+      return newUser;
     })
   };
 
@@ -25,9 +25,9 @@ module.exports = function(models) {
         return false;
       }
 
-      if (bcrypt.compareSync(password, user.dataValues.password)) {
+      if (bcrypt.compareSync(password, user.password)) {
         return {
-          id: user.dataValues.id
+          id: user.id
         };
       }
       return false;

--- a/services/baseDbService.js
+++ b/services/baseDbService.js
@@ -17,9 +17,7 @@ var baseDbService = function(Model, outputSanitizer) {
 
   var findAll = function() {
     return Model.findAll().then(function(rows) {
-      return _sanitizeOutput(rows.map(function(row) {
-        return row.dataValues;
-      }));
+      return _sanitizeOutput(rows);
     })
   };
 
@@ -30,9 +28,7 @@ var baseDbService = function(Model, outputSanitizer) {
       if (rows.length === 0) {
         return rows;
       }
-      return _sanitizeOutput(rows.map(function(row) {
-        return row.dataValues;
-      }));
+      return _sanitizeOutput(rows);
     })
   };
 
@@ -44,9 +40,7 @@ var baseDbService = function(Model, outputSanitizer) {
       if (rows.length === 0) {
         return rows;
       }
-      return _sanitizeOutput(rows.map(function(row) {
-        return row.dataValues;
-      }));
+      return _sanitizeOutput(rows);
     })
   };
 
@@ -56,7 +50,7 @@ var baseDbService = function(Model, outputSanitizer) {
       if (!row) {
         return [];
       }
-      return _sanitizeOutput(row.dataValues);
+      return _sanitizeOutput(row);
     })
   };
 
@@ -65,15 +59,13 @@ var baseDbService = function(Model, outputSanitizer) {
       if (row.length === 0) {
         return [];
       }
-      return _sanitizeOutput(row[0].dataValues);
+      return _sanitizeOutput(row[0]);
     })
   };
 
   var findByUser = function(userId) {
     return Model.findAll({where: {userId: userId}}).then(function(rows) {
-      return _sanitizeOutput(rows.map(function(row) {
-        return row.dataValues;
-      }))
+      return _sanitizeOutput(rows)
     })
   };
 
@@ -82,13 +74,13 @@ var baseDbService = function(Model, outputSanitizer) {
       if (!row) {
         return [];
       }
-      return _sanitizeOutput(row.dataValues);
+      return _sanitizeOutput(row);
     })
   };
 
   var create = function(data) {
     return Model.create(data).then(function(newRow) {
-      return _sanitizeOutput(newRow.dataValues);
+      return _sanitizeOutput(newRow);
     })
   };
 
@@ -104,7 +96,7 @@ var baseDbService = function(Model, outputSanitizer) {
         return Promise.resolve(false);
       }
       return row.update(data).then(function(updatedRow) {
-        return _sanitizeOutput(updatedRow.dataValues);
+        return _sanitizeOutput(updatedRow);
       })
     });
   };
@@ -115,7 +107,7 @@ var baseDbService = function(Model, outputSanitizer) {
         return Promise.resolve(false);
       }
       return row.update(data).then(function(updatedRow) {
-        return _sanitizeOutput(updatedRow.dataValues);
+        return _sanitizeOutput(updatedRow);
       })
     });
   };

--- a/services/baseReminderService.js
+++ b/services/baseReminderService.js
@@ -7,40 +7,37 @@ module.exports = function(models) {
   var baseReminderService = require('./baseDbService')(BaseReminder);
 
   baseReminderService.findAll = function() {
-    return BaseReminder.findAll({include: [Timeframe, Category]}).then(function(resp) {
-      var baseReminders = resp.map(function(resp) {
-        return resp.dataValues;
-      });
-
-      return baseReminders.map(function(baseReminder) {
-        baseReminder.timeframeIds = baseReminder.Timeframes.map(function(timeframeResp) {
-          return timeframeResp.dataValues.id;
+    return BaseReminder.findAll({include: [Timeframe, Category]})
+      .then(function(baseReminders) {
+        return baseReminders.map(function(baseReminder){
+          var json = baseReminder.toJSON();
+          json.timeframeIds = [];
+          json.timeframes = [];
+          json.Timeframes.forEach(function(Timeframe) {
+            json.timeframeIds.push(Timeframe.id);
+            json.timeframes.push(Timeframe.name);
+          })
+          json.categoryName = baseReminder.Category.name;
+          delete json.Timeframes;
+          delete json.Category;
+          return json;
         });
-        baseReminder.timeframes = baseReminder.Timeframes.map(function(timeframeResp) {
-          return timeframeResp.dataValues.name;
-        });
-        baseReminder.categoryName = baseReminder.Category.dataValues.name;
-        delete baseReminder.Timeframes;
-        delete baseReminder.Category;
-        return baseReminder;
-      });
-
-    });
-  };
+      })
+  }
 
   baseReminderService.findAllIncludingTimeframes = function() {
     return BaseReminder.findAll({include: Timeframe}).then(function(resp) {
       var baseReminders = resp.map(function(resp) {
-        return resp.dataValues;
+        return resp;
       });
 
       return baseReminders.map(function(baseReminder) {
         baseReminder.timeframes = baseReminder.Timeframes.map(function(timeframeResp) {
           return {
-            id: timeframeResp.dataValues.id,
-            name: timeframeResp.dataValues.name,
-            type: timeframeResp.dataValues.type,
-            formula: timeframeResp.dataValues.formula
+            id: timeframeResp.id,
+            name: timeframeResp.name,
+            type: timeframeResp.type,
+            formula: timeframeResp.formula
           }
         });
         delete baseReminder.Timeframes;
@@ -50,23 +47,23 @@ module.exports = function(models) {
   };
 
   baseReminderService.findById = function(id) {
-    return BaseReminder.findById(id, {include: [Timeframe, Category]}).then(function(resp) {
-      if (!resp) {
+    return BaseReminder.findById(id, {include: [Timeframe, Category]}).then(function(baseReminder) {
+      if (!baseReminder) {
         return [];
       }
 
-      var baseReminder = resp.dataValues;
+      var json = baseReminder.toJSON();
 
-      baseReminder.timeframeIds = baseReminder.Timeframes.map(function(timeframeResp) {
-        return timeframeResp.dataValues.id;
+      json.timeframeIds = baseReminder.Timeframes.map(function(timeframeResp) {
+        return timeframeResp.id;
       });
-      baseReminder.timeframes = baseReminder.Timeframes.map(function(timeframeResp) {
-        return timeframeResp.dataValues.name;
+      json.timeframes = baseReminder.Timeframes.map(function(timeframeResp) {
+        return timeframeResp.name;
       });
-      baseReminder.categoryName = baseReminder.Category.dataValues.name;
-      delete baseReminder.Timeframes;
-      delete baseReminder.Category;
-      return [baseReminder];
+      json.categoryName = baseReminder.Category.name;
+      delete json.Timeframes;
+      delete json.Category;
+      return [json];
 
     });
   };
@@ -75,10 +72,10 @@ module.exports = function(models) {
     var timeframes = data.timeframeIds;
 
     return BaseReminder.create(data).then(function(newBaseReminder) {
-      var baseReminder = newBaseReminder.dataValues;
       return newBaseReminder.setTimeframes(timeframes).then(function() {
-        baseReminder.timeframeIds = data.timeframeIds;
-        return [baseReminder];
+        var json = newBaseReminder.toJSON();
+        json.timeframeIds = data.timeframeIds;
+        return [json];
       });
     });
   };
@@ -90,18 +87,18 @@ module.exports = function(models) {
       }
 
       return baseReminder.update(data).then(function(updatedBaseReminder) {
-        var baseReminder = updatedBaseReminder.dataValues;
+        var json = updatedBaseReminder.toJSON();
         if (data.timeframeIds) {
           return updatedBaseReminder.setTimeframes(data.timeframeIds).then(function() {
-            baseReminder.timeframeIds = data.timeframeIds;
-            return [baseReminder];
+            json.timeframeIds = data.timeframeIds;
+            return [json];
           });
         }
         return updatedBaseReminder.getTimeframes().then(function(timeframes) {
-          baseReminder.timeframeIds = timeframes.map(function(timeframe) {
-            return timeframe.dataValues.id;
+          json.timeframeIds = timeframes.map(function(timeframe) {
+            return timeframe.id;
           });
-          return [baseReminder];
+          return [json];
         })
       })
     })

--- a/services/cipherService.js
+++ b/services/cipherService.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var salt = process.env.SECRET_SALT || 'development_secret_salt';
+var crypto = require('crypto');
+
+module.exports = {
+  encrypt: function(value) {
+    var cipher = crypto.createCipher('aes192', salt);
+    var encryptedValue = cipher.update(value, 'utf8', 'hex');
+    encryptedValue += cipher.final('hex');
+    return encryptedValue;
+  },
+  decrypt: function(encryptedValue) {
+    var decipher = crypto.createDecipher('aes192', salt);
+    var value = decipher.update(encryptedValue, 'hex', 'utf8');
+    value += decipher.final('utf8');
+    return value;
+  }
+}

--- a/services/reminderService.js
+++ b/services/reminderService.js
@@ -7,29 +7,24 @@ module.exports = function(models) {
   var Category = models.Category;
   var School = models.School;
 
-  var outputSanitizer = function(reminder) {
-    reminder.dueDate = moment.utc(reminder.dueDate).format('YYYY-MM-DD');
-    return reminder;
-  };
-
-  var reminderService = require('./baseDbService')(Reminder, outputSanitizer);
+  var reminderService = require('./baseDbService')(Reminder);
 
   function getReminderResponse(row) {
     return {
-      id: row.dataValues.id,
-      dueDate: moment.utc(row.dataValues.dueDate).format('YYYY-MM-DD'),
-      timeframe: row.dataValues.timeframe,
-      name: row.dataValues.BaseReminder.dataValues.name,
-      message: row.dataValues.BaseReminder.dataValues.message,
-      detail: row.dataValues.BaseReminder.dataValues.detail,
-      lateMessage: row.dataValues.BaseReminder.dataValues.lateMessage,
-      lateDetail: row.dataValues.BaseReminder.dataValues.lateDetail,
-      category: row.dataValues.BaseReminder.dataValues.Category.dataValues.name,
-      baseReminderId: row.dataValues.BaseReminder.dataValues.id,
-      schoolName: row.dataValues.School.dataValues.name,
-      schoolId: row.dataValues.School.dataValues.id,
-      schoolDueDate: row.dataValues.School.dataValues.dueDate,
-      userId: row.dataValues.userId
+      id: row.id,
+      dueDate: moment.utc(row.dueDate).format('YYYY-MM-DD'),
+      timeframe: row.timeframe,
+      name: row.BaseReminder.name,
+      message: row.BaseReminder.message,
+      detail: row.BaseReminder.detail,
+      lateMessage: row.BaseReminder.lateMessage,
+      lateDetail: row.BaseReminder.lateDetail,
+      category: row.BaseReminder.Category.name,
+      baseReminderId: row.BaseReminder.id,
+      schoolName: row.School.name,
+      schoolId: row.School.id,
+      schoolDueDate: row.School.dueDate,
+      userId: row.userId
     }
   }
 

--- a/services/schoolService.js
+++ b/services/schoolService.js
@@ -3,10 +3,5 @@
 var moment = require('moment');
 
 module.exports = function(models) {
-  var outputSanitizer = function(school) {
-    school.dueDate = moment.utc(school.dueDate).format('YYYY-MM-DD');
-    return school;
-  };
-
-  return require('./baseDbService')(models.School, outputSanitizer);
+  return require('./baseDbService')(models.School);
 };

--- a/services/testDateService.js
+++ b/services/testDateService.js
@@ -6,13 +6,7 @@ module.exports = function(models) {
   var TestDate = models.TestDate;
   var Test = models.Test;
 
-  var outputSanitizer = function(testDate) {
-    testDate.adminDate = moment.utc(testDate.adminDate).format('YYYY-MM-DD');
-    testDate.registrationDate = moment.utc(testDate.registrationDate).format('YYYY-MM-DD');
-    return testDate;
-  };
-
-  var testDateService = require('./baseDbService')(TestDate, outputSanitizer);
+  var testDateService = require('./baseDbService')(TestDate);
 
   testDateService.findAll = function() {
     return TestDate.findAll({
@@ -20,15 +14,15 @@ module.exports = function(models) {
     }).then(function(rows) {
       return rows.map(function(row) {
         return {
-          id: row.dataValues.id,
-          testId: row.dataValues.testId,
-          registrationDate: _formatDate(row.dataValues.registrationDate),
-          adminDate: _formatDate(row.dataValues.adminDate),
-          type: row.dataValues.Test.dataValues.type,
-          registrationMessage: row.dataValues.Test.dataValues.registrationMessage,
-          registrationDetail: row.dataValues.Test.dataValues.registrationDetail,
-          adminMessage: row.dataValues.Test.dataValues.adminMessage,
-          adminDetail: row.dataValues.Test.dataValues.adminDetail
+          id: row.id,
+          testId: row.testId,
+          registrationDate: _formatDate(row.registrationDate),
+          adminDate: _formatDate(row.adminDate),
+          type: row.Test.type,
+          registrationMessage: row.Test.registrationMessage,
+          registrationDetail: row.Test.registrationDetail,
+          adminMessage: row.Test.adminMessage,
+          adminDetail: row.Test.adminDetail
         }
       });
     })

--- a/services/userService.js
+++ b/services/userService.js
@@ -1,11 +1,13 @@
 'use strict';
+var cipher = require('./cipherService');
 
 module.exports = function(models) {
   var User = models.User;
   var userService = require('./baseDbService')(User);
 
   userService.getUserByPhoneNumber = function(phoneNumber) {
-    return User.findOne({where: {phoneNumber: phoneNumber}}).then(function(user) {
+    var encryptedPhoneNumber = cipher.encrypt(phoneNumber);
+    return User.findOne({where: {phoneNumber: encryptedPhoneNumber}}).then(function(user) {
       return user;
     })
   };

--- a/test/e2e/user_spec.js
+++ b/test/e2e/user_spec.js
@@ -64,7 +64,7 @@ describe('The userService', function() {
 
   it('should get a user by phone number', function() {
     return userService.getUserByPhoneNumber('1234567890').then(function(users) {
-      users.dataValues.id.should.equal(1);
+      users.id.should.equal(1);
     })
   })
 

--- a/test/unit/adminUserService_spec.js
+++ b/test/unit/adminUserService_spec.js
@@ -35,7 +35,7 @@ describe('The AdminUsers Service', function() {
 
     it('should return user id if the user password matches the salted-hashed password', function() {
       mocks.stubs.AdminUser.findOne.withArgs({where: {userName: 'admin'}})
-        .returns(Promise.resolve({dataValues: adminUser}));
+        .returns(Promise.resolve(adminUser));
       mocks.stubs.bcrypt.compareSync.withArgs('password', 'salted hashed password')
         .returns(adminUser);
 
@@ -72,7 +72,7 @@ describe('The AdminUsers Service', function() {
       mocks.stubs.bcrypt.hashSync.withArgs('password', 'salt')
         .returns('salted hashed password');
       mocks.stubs.AdminUser.create.withArgs({userName: 'admin', password: 'salted hashed password'})
-        .returns(Promise.resolve({dataValues: newAdminUser}));
+        .returns(Promise.resolve(newAdminUser));
 
       return adminUserService.create('admin', 'password').should.eventually.deep.equal(newAdminUser);
     });

--- a/test/unit/baseReminderService_spec.js
+++ b/test/unit/baseReminderService_spec.js
@@ -21,7 +21,7 @@ describe('The BaseReminders Service', function() {
 
     baseReminderService = require('../../services/baseReminderService')(mocks.modelMock);
 
-    baseRemindersDbResponse = [{dataValues: {
+    baseRemindersDbResponse = [{
       id: 1,
       name: 'Write Essays',
       message: 'Write Your Essays',
@@ -30,13 +30,26 @@ describe('The BaseReminders Service', function() {
       lateDetail: 'What to do about late essays',
       categoryId: 1,
       Timeframes: [
-        {dataValues: {id: 1, name: '90 Days'}},
-        {dataValues: {id: 2, name: '60 Days'}}
+        {id: 1, name: '90 Days'},
+        {id: 2, name: '60 Days'}
       ],
       Category: {
-        dataValues: {id: 1, name: 'Essays'}
+        id: 1, name: 'Essays'
+      },
+      toJSON: function() {
+        return {
+          id: this.id,
+          name: this.name,
+          message: this.message,
+          detail: this.detail,
+          lateMessage: this.lateMessage,
+          lateDetail: this.lateDetail,
+          categoryId: this.categoryId,
+          Timeframes: this.Timeframes,
+          Category: this.Category
+        };
       }
-    }}, {dataValues: {
+    }, {
       id: 1,
       name: 'Get Recommendations',
       message: 'Ask counselor for recommendations',
@@ -45,12 +58,25 @@ describe('The BaseReminders Service', function() {
       lateDetail: 'What to do about late recommendations',
       categoryId: 1,
       Timeframes: [
-        {dataValues: {id: 3, name: '30 Days'}}
+        {id: 3, name: '30 Days'}
       ],
       Category: {
-        dataValues: {id: 1, name: 'Essays'}
+        id: 1, name: 'Essays'
+      },
+      toJSON: function() {
+        return {
+          id: this.id,
+          name: this.name,
+          message: this.message,
+          detail: this.detail,
+          lateMessage: this.lateMessage,
+          lateDetail: this.lateDetail,
+          categoryId: this.categoryId,
+          Timeframes: this.Timeframes,
+          Category: this.Category
+        };
       }
-    }}];
+    }];
     baseReminders = [{
       id: 1,
       name: 'Write Essays',
@@ -102,49 +128,40 @@ describe('The BaseReminders Service', function() {
 
     beforeEach(function() {
       baseRemindersIncludingTimeframes = [{
-        dataValues: {
-          id: '1',
-          name: 'Write Essay',
-          message: 'Better get writing!',
-          detail: 'Some help for writing your essay',
-          lateMessage: 'Too late',
-          lateDetail: 'Should have started sooner',
-          Timeframes: [{
-            dataValues: {
-              id: 1,
-              name: 'Today',
-              type: 'now',
-              formula: undefined
-            }
-          }, {
-            dataValues: {
-              id: 2,
-              name: 'In 30 Days',
-              type: 'relative',
-              formula: '30'
-            }
-          }],
-          categoryId: 1
-        }
+        id: '1',
+        name: 'Write Essay',
+        message: 'Better get writing!',
+        detail: 'Some help for writing your essay',
+        lateMessage: 'Too late',
+        lateDetail: 'Should have started sooner',
+        Timeframes: [{
+          id: 1,
+          name: 'Today',
+          type: 'now',
+          formula: undefined
+        }, {
+          id: 2,
+          name: 'In 30 Days',
+          type: 'relative',
+          formula: '30'
+        }],
+        categoryId: 1
       }, {
-        dataValues: {
-          id: '2',
-          name: 'Get Recommendations',
-          message: 'Ask your counselor',
-          detail: 'Tips for asking your counselor',
-          lateMessage: 'Too late',
-          lateDetail: '',
-          Timeframes: [{
-            dataValues: {
-              id: 3,
-              name: 'January 1',
-              type: 'absolute',
-              formula: '2017-01-01'
-            }
-          }],
-          categoryId: 2
+        id: '2',
+        name: 'Get Recommendations',
+        message: 'Ask your counselor',
+        detail: 'Tips for asking your counselor',
+        lateMessage: 'Too late',
+        lateDetail: '',
+        Timeframes: [{
+          id: 3,
+          name: 'January 1',
+          type: 'absolute',
+          formula: '2017-01-01'
+        }],
+        categoryId: 2
         }
-      }];
+      ];
     });
 
     it('should resolve with baseReminder objects that include an array of Timeframes belonging to it', function() {
@@ -222,25 +239,29 @@ describe('The BaseReminders Service', function() {
 
     beforeEach(function() {
       newBaseReminderDbResponse = {
-        dataValues: {
-          name: 'Write Essays',
-          message: 'Write Your Essays',
-          detail: 'More detail about essays',
-          lateMessage: 'Your Essays are late',
-          lateDetail: 'What to do about late essays',
-          categoryId: 1
-        },
-        setTimeframes: function(){}
+        name: 'Write Essays',
+        message: 'Write Your Essays',
+        detail: 'More detail about essays',
+        lateMessage: 'Your Essays are late',
+        lateDetail: 'What to do about late essays',
+        categoryId: 1,
+        setTimeframes: function(){},
+        toJSON: function() {
+          return {
+            name: this.name,
+            message: this.message,
+            detail: this.detail,
+            lateMessage: this.lateMessage,
+            lateDetail: this.lateDetail,
+            categoryId: this.categoryId
+          };
+        }
       };
 
       newTimeframeAssociations = [[{
-        dataValues: {
-          TimeframeId: 1
-        }
+        TimeframeId: 1
       }, {
-        dataValues: {
-          TimeframeId: 2
-        }
+        TimeframeId: 2
       }]];
 
       setTimeframes = sinon.stub(newBaseReminderDbResponse, 'setTimeframes');
@@ -285,35 +306,36 @@ describe('The BaseReminders Service', function() {
 
     beforeEach(function() {
       updatedBaseReminderDbResponse = {
-        dataValues: {
-          name: 'Write Essays',
-          message: 'Write Your Essays',
-          detail: 'More detail about essays',
-          lateMessage: 'Your Essays are late',
-          lateDetail: 'What to do about late essays',
-          categoryId: 1
-        },
+        name: 'Write Essays',
+        message: 'Write Your Essays',
+        detail: 'More detail about essays',
+        lateMessage: 'Your Essays are late',
+        lateDetail: 'What to do about late essays',
+        categoryId: 1,
         setTimeframes: function(){},
-        getTimeframes: function(){}
+        getTimeframes: function(){},
+        toJSON: function() {
+          return {
+            name: this.name,
+            message: this.message,
+            detail: this.detail,
+            lateMessage: this.lateMessage,
+            lateDetail: this.lateDetail,
+            categoryId: this.categoryId
+          };
+        }
       };
 
       updatedTimeframeAssociations = [[{
-        dataValues: {
-          TimeframeId: 1
-        }
+        TimeframeId: 1
       }, {
-        dataValues: {
-          TimeframeId: 2
-        }
+        TimeframeId: 2
       }]];
 
       associatedTimeframes = [{
-        dataValues: {
-          id: 1
-        }}, {
-        dataValues: {
-          id: 2
-        }
+        id: 1
+      }, {
+        id: 2
       }];
 
       baseReminder = {

--- a/test/unit/categoryService_spec.js
+++ b/test/unit/categoryService_spec.js
@@ -29,11 +29,7 @@ describe('The Categories Service', function() {
 
   describe('The findAll function', function() {
     it('should resolve with an array of objects representing categories', function() {
-      mocks.stubs.Category.findAll.returns(Promise.resolve(categories.map(
-        function(category) {
-          return {dataValues: category};
-        }
-      )));
+      mocks.stubs.Category.findAll.returns(Promise.resolve(categories));
 
       return categoryService.findAll().should.eventually.deep.equal(categories);
     });
@@ -48,7 +44,7 @@ describe('The Categories Service', function() {
   describe('The findById function', function() {
     it('should resolve with an array with the matching category object', function() {
       mocks.stubs.Category.findById.withArgs(1)
-        .returns(Promise.resolve({dataValues: categories[0]}));
+        .returns(Promise.resolve(categories[0]));
 
       return categoryService.findById(1).should.eventually.deep.equal([categories[0]]);
     });
@@ -68,7 +64,7 @@ describe('The Categories Service', function() {
 
     it('should resolve with an array containing the new category object', function() {
       mocks.stubs.Category.create.withArgs(newCategory)
-        .returns(Promise.resolve({dataValues: newCategory}));
+        .returns(Promise.resolve(newCategory));
 
       return categoryService.create(newCategory).should.eventually.deep.equal([newCategory]);
     });
@@ -95,7 +91,7 @@ describe('The Categories Service', function() {
       mocks.stubs.Category.findById.withArgs(idToUpdate)
         .returns(Promise.resolve(row));
       update.withArgs(updatedCategory)
-        .returns(Promise.resolve({dataValues: updatedCategory}));
+        .returns(Promise.resolve(updatedCategory));
 
       return categoryService.update(idToUpdate, updatedCategory).should.eventually.deep.equal([updatedCategory]);
     });

--- a/test/unit/cipherService_spec.js
+++ b/test/unit/cipherService_spec.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var sinon = require('sinon');
+var chai = require('chai');
+var sinonChai = require('sinon-chai');
+chai.use(sinonChai);
+chai.should();
+
+describe('The Cipher Service', function() {
+  var crypto, cipher;
+  var cipherUpdateMock, cipherFinalMock;
+  var decipherUpdateMock, decipherFinalMock;
+
+  beforeEach(function() {
+    crypto = require('crypto');
+    crypto.createCipher = function() {
+      return {
+        update: function(){return 'ENCRYPT'},
+        final: function(){return 'ED'}
+      }
+    }
+    crypto.createDecipher = function() {
+      return {
+        update: function(){return 'DECRYPT'},
+        final: function(){return 'ED'}
+      }
+    }
+    cipher = require('../../services/cipherService');
+  });
+
+  describe('Encrypt method', function() {
+    it('encrypts and returns the encrypted value', function() {
+      cipher.encrypt('DECRYPTED').should.equal('ENCRYPTED');
+    });
+  });
+
+  describe('Decrypt method', function() {
+    it('decrypts and returns the decrypted value', function() {
+      cipher.decrypt('ENCRYPTED').should.equal('DECRYPTED');
+    });
+  });
+});

--- a/test/unit/contentItemService_spec.js
+++ b/test/unit/contentItemService_spec.js
@@ -39,11 +39,7 @@ describe('The ContentItems Service', function() {
 
   describe('The findAll function', function() {
     it('should resolve with an array of objects representing contentItems', function() {
-      mocks.stubs.ContentItem.findAll.returns(Promise.resolve(contentItems.map(
-        function(contentItem) {
-          return {dataValues: contentItem};
-        }
-      )));
+      mocks.stubs.ContentItem.findAll.returns(Promise.resolve(contentItems));
 
       return contentItemService.findAll().should.eventually.deep.equal(contentItems);
     });
@@ -58,7 +54,7 @@ describe('The ContentItems Service', function() {
   describe('The findById function', function() {
     it('should resolve with an array with the matching contentItem object', function() {
       mocks.stubs.ContentItem.findAll.withArgs({where: {name: 'faqs'}})
-        .returns(Promise.resolve([{dataValues: contentItems[0]}]));
+        .returns(Promise.resolve([contentItems[0]]));
 
       return contentItemService.findByName('faqs').should.eventually.deep.equal([contentItems[0]]);
     });
@@ -79,7 +75,7 @@ describe('The ContentItems Service', function() {
 
     it('should resolve with an array containing the new contentItem object', function() {
       mocks.stubs.ContentItem.create.withArgs(newContentItem)
-        .returns(Promise.resolve({dataValues: newContentItem}));
+        .returns(Promise.resolve(newContentItem));
 
       return contentItemService.create(newContentItem).should.eventually.deep.equal([newContentItem]);
     });
@@ -108,7 +104,7 @@ describe('The ContentItems Service', function() {
       mocks.stubs.ContentItem.findById.withArgs(idToUpdate)
         .returns(Promise.resolve(row));
       update.withArgs(updatedContentItem)
-        .returns(Promise.resolve({dataValues: updatedContentItem}));
+        .returns(Promise.resolve(updatedContentItem));
 
       return contentItemService.update(idToUpdate, updatedContentItem).should.eventually.deep.equal([updatedContentItem]);
     });

--- a/test/unit/reminderService_spec.js
+++ b/test/unit/reminderService_spec.js
@@ -17,66 +17,50 @@ describe('The Reminders Service', function() {
   var reminderService;
   
   var dbResponse = [{
-    dataValues: {
+    id: '1',
+    userId: '1',
+    dueDate: '2017-02-01',
+    timeframe: 'One week before',
+    BaseReminder: {
       id: '1',
-      userId: '1',
-      dueDate: '2017-02-01',
-      timeframe: 'One week before',
-      BaseReminder: {
-        dataValues: {
-          id: '1',
-          name: 'Write Essay',
-          message: 'Better get writing!',
-          detail: 'Some help for writing your essay',
-          lateMessage: 'Too late',
-          lateDetail: 'Should have started sooner',
-          categoryId: 1,
-          Category: {
-            dataValues: {
-              id: 1,
-              name: 'Essays'
-            }
-          }
-        }
-      },
-      School: {
-        dataValues: {
-          id: '1',
-          name: 'Temple',
-          dueDate: '2017-02-01'
-        }
+      name: 'Write Essay',
+      message: 'Better get writing!',
+      detail: 'Some help for writing your essay',
+      lateMessage: 'Too late',
+      lateDetail: 'Should have started sooner',
+      categoryId: 1,
+      Category: {
+        id: 1,
+        name: 'Essays'
       }
+    },
+    School: {
+      id: '1',
+      name: 'Temple',
+      dueDate: '2017-02-01'
     }
   }, {
-    dataValues: {
+    id: '2',
+    userId: '1',
+    dueDate: '2017-02-01',
+    timeframe: 'One week before',
+    BaseReminder: {
       id: '2',
-      userId: '1',
-      dueDate: '2017-02-01',
-      timeframe: 'One week before',
-      BaseReminder: {
-        dataValues: {
-          id: '2',
-          name: 'Get Recommendations',
-          message: 'Ask your counselor',
-          detail: 'Tips for asking your counselor',
-          lateMessage: 'Too late',
-          lateDetail: '',
-          categoryId: '2',
-          Category: {
-            dataValues: {
-              id: '2',
-              name: 'Recommendations'
-            }
-          }
-        }
-      },
-      School: {
-        dataValues: {
-          id: '1',
-          name: 'Temple',
-          dueDate: '2017-02-01'
-        }
+      name: 'Get Recommendations',
+      message: 'Ask your counselor',
+      detail: 'Tips for asking your counselor',
+      lateMessage: 'Too late',
+      lateDetail: '',
+      categoryId: '2',
+      Category: {
+        id: '2',
+        name: 'Recommendations'
       }
+    },
+    School: {
+      id: '1',
+      name: 'Temple',
+      dueDate: '2017-02-01'
     }
   }];
 

--- a/test/unit/schoolService_spec.js
+++ b/test/unit/schoolService_spec.js
@@ -40,7 +40,7 @@ describe('The Schools Service', function() {
     it('should resolve with an array of objects representing schools', function() {
       mocks.stubs.School.findAll.returns(Promise.resolve(schools.map(
         function(school) {
-          return {dataValues: school};
+          return school;
         }
       )));
 
@@ -57,7 +57,7 @@ describe('The Schools Service', function() {
   describe('The findByIdForUser function', function() {
     it('should resolve with an array with the matching school object', function() {
       mocks.stubs.School.findOne.withArgs({where: {id: 1, userId: 1}})
-        .returns(Promise.resolve({dataValues: schools[0]}));
+        .returns(Promise.resolve(schools[0]));
 
       return schoolService.findByIdForUser(1, 1).should.eventually.deep.equal([schools[0]]);
     });
@@ -80,7 +80,7 @@ describe('The Schools Service', function() {
 
     it('should resolve with an array containing the new school object', function() {
       mocks.stubs.School.create.withArgs(newSchool)
-        .returns(Promise.resolve({dataValues: newSchool}));
+        .returns(Promise.resolve(newSchool));
 
       return schoolService.create(newSchool).should.eventually.deep.equal([newSchool]);
     });
@@ -111,7 +111,7 @@ describe('The Schools Service', function() {
       mocks.stubs.School.findOne.withArgs({where: {id: 1, userId: 1}})
         .returns(Promise.resolve(row));
       update.withArgs(updatedSchool)
-        .returns(Promise.resolve({dataValues: updatedSchool}));
+        .returns(Promise.resolve(updatedSchool));
 
       return schoolService.updateForUser(idToUpdate, updatedSchool, 1)
         .should.eventually.deep.equal([updatedSchool]);

--- a/test/unit/testDateService_spec.js
+++ b/test/unit/testDateService_spec.js
@@ -55,45 +55,29 @@ describe('The TestDates Service', function() {
       }];
 
       dbResponse = [{
-        dataValues: {
-          id: '1',
-          testId: '1',
-          registrationDate: '2016-09-01',
-          adminDate: '2016-10-01',
-          Test: {
-            dataValues: tests[0]
-          }
-        }
+        id: '1',
+        testId: '1',
+        registrationDate: '2016-09-01',
+        adminDate: '2016-10-01',
+        Test: tests[0]
       }, {
-        dataValues: {
-          id: '2',
-          testId: '1',
-          registrationDate: '2016-09-15',
-          adminDate: '2016-10-15',
-          Test: {
-            dataValues: tests[0]
-          }
-        }
+        id: '2',
+        testId: '1',
+        registrationDate: '2016-09-15',
+        adminDate: '2016-10-15',
+        Test: tests[0]
       }, {
-        dataValues: {
-          id: '3',
-          testId: '2',
-          registrationDate: '2017-01-01',
-          adminDate: '2016-02-01',
-          Test: {
-            dataValues: tests[1]
-          }
-        }
+        id: '3',
+        testId: '2',
+        registrationDate: '2017-01-01',
+        adminDate: '2016-02-01',
+        Test: tests[1]
       }, {
-        dataValues: {
-          id: '4',
-          testId: '2',
-          registrationDate: '2017-01-15',
-          adminDate: '2016-02-15',
-          Test: {
-            dataValues: tests[1]
-          }
-        }
+        id: '4',
+        testId: '2',
+        registrationDate: '2017-01-15',
+        adminDate: '2016-02-15',
+        Test: tests[1]
       }];
     });
 
@@ -157,7 +141,7 @@ describe('The TestDates Service', function() {
   describe('The findById function', function() {
     it('should resolve with an array with the matching testDate object', function() {
       mocks.stubs.TestDate.findById.withArgs(1)
-        .returns(Promise.resolve({dataValues: testDates[0]}));
+        .returns(Promise.resolve(testDates[0]));
 
       return testDateService.findById(1).should.eventually.deep.equal([testDates[0]]);
     });
@@ -180,7 +164,7 @@ describe('The TestDates Service', function() {
 
     it('should resolve with an array containing the new testDate object', function() {
       mocks.stubs.TestDate.create.withArgs(newTestDate)
-        .returns(Promise.resolve({dataValues: newTestDate}));
+        .returns(Promise.resolve(newTestDate));
 
       return testDateService.create(newTestDate).should.eventually.deep.equal([newTestDate]);
     });
@@ -210,7 +194,7 @@ describe('The TestDates Service', function() {
       mocks.stubs.TestDate.findById.withArgs(idToUpdate)
         .returns(Promise.resolve(row));
       update.withArgs(updatedTestDate)
-        .returns(Promise.resolve({dataValues: updatedTestDate}));
+        .returns(Promise.resolve(updatedTestDate));
 
       return testDateService.update(idToUpdate, updatedTestDate).should.eventually.deep.equal([updatedTestDate]);
     });

--- a/test/unit/testService_spec.js
+++ b/test/unit/testService_spec.js
@@ -44,11 +44,7 @@ describe('The Tests Service', function() {
 
   describe('The findAll function', function() {
     it('should resolve with an array of objects representing tests', function() {
-      mocks.stubs.Test.findAll.returns(Promise.resolve(tests.map(
-        function(test) {
-          return {dataValues: test};
-        }
-      )));
+      mocks.stubs.Test.findAll.returns(Promise.resolve(tests));
 
       return testService.findAll().should.eventually.deep.equal(tests);
     });
@@ -63,7 +59,7 @@ describe('The Tests Service', function() {
   describe('The findById function', function() {
     it('should resolve with an array with the matching test object', function() {
       mocks.stubs.Test.findById.withArgs(1)
-        .returns(Promise.resolve({dataValues: tests[0]}));
+        .returns(Promise.resolve(tests[0]));
 
       return testService.findById(1).should.eventually.deep.equal([tests[0]]);
     });
@@ -87,7 +83,7 @@ describe('The Tests Service', function() {
 
     it('should resolve with an array containing the new test object', function() {
       mocks.stubs.Test.create.withArgs(newTest)
-        .returns(Promise.resolve({dataValues: newTest}));
+        .returns(Promise.resolve(newTest));
 
       return testService.create(newTest).should.eventually.deep.equal([newTest]);
     });
@@ -119,7 +115,7 @@ describe('The Tests Service', function() {
       mocks.stubs.Test.findById.withArgs(idToUpdate)
         .returns(Promise.resolve(row));
       update.withArgs(updatedTest)
-        .returns(Promise.resolve({dataValues: updatedTest}));
+        .returns(Promise.resolve(updatedTest));
 
       return testService.update(idToUpdate, updatedTest).should.eventually.deep.equal([updatedTest]);
     });

--- a/test/unit/timeframeService_spec.js
+++ b/test/unit/timeframeService_spec.js
@@ -41,11 +41,7 @@ describe('The Timeframes Service', function() {
 
   describe('The findAll function', function() {
     it('should resolve with an array of objects representing timeframes', function() {
-      mocks.stubs.Timeframe.findAll.returns(Promise.resolve(timeframes.map(
-        function(timeframe) {
-          return {dataValues: timeframe};
-        }
-      )));
+      mocks.stubs.Timeframe.findAll.returns(Promise.resolve(timeframes));
 
       return timeframeService.findAll().should.eventually.deep.equal(timeframes);
     });
@@ -60,7 +56,7 @@ describe('The Timeframes Service', function() {
   describe('The findById function', function() {
     it('should resolve with an array with the matching timeframe object', function() {
       mocks.stubs.Timeframe.findById.withArgs(1)
-        .returns(Promise.resolve({dataValues: timeframes[0]}));
+        .returns(Promise.resolve(timeframes[0]));
 
       return timeframeService.findById(1).should.eventually.deep.equal([timeframes[0]]);
     });
@@ -82,7 +78,7 @@ describe('The Timeframes Service', function() {
 
     it('should resolve with an array containing the new timeframe object', function() {
       mocks.stubs.Timeframe.create.withArgs(newTimeframe)
-        .returns(Promise.resolve({dataValues: newTimeframe}));
+        .returns(Promise.resolve(newTimeframe));
 
       return timeframeService.create(newTimeframe).should.eventually.deep.equal([newTimeframe]);
     });
@@ -112,7 +108,7 @@ describe('The Timeframes Service', function() {
       mocks.stubs.Timeframe.findById.withArgs(idToUpdate)
         .returns(Promise.resolve(row));
       update.withArgs(updatedTimeframe)
-        .returns(Promise.resolve({dataValues: updatedTimeframe}));
+        .returns(Promise.resolve(updatedTimeframe));
 
       return timeframeService.update(idToUpdate, updatedTimeframe).should.eventually.deep.equal([updatedTimeframe]);
     });

--- a/test/unit/userService_spec.js
+++ b/test/unit/userService_spec.js
@@ -10,7 +10,7 @@ chai.should();
 
 describe('The Users Service', function() {
   var mocks = require('../mocks')('User');
-  var userService;
+  var cipher, userService;
 
   var users = [{
     id: 1,
@@ -27,7 +27,10 @@ describe('The Users Service', function() {
   
   beforeEach(function() {
     mocks.stubMethods();
-
+    cipher = require('../../services/cipherService');
+    cipher.encrypt = function() {
+      return 'ENCRYPTED'
+    }
     userService = require('../../services/userService')(mocks.modelMock);
   });
 
@@ -68,14 +71,14 @@ describe('The Users Service', function() {
   describe('The getUserByPhoneNumber function', function() {
     it('should resolve with  the matching user object', function() {
       var userObj = {dataValues: users[0]};
-      mocks.stubs.User.findOne.withArgs({where: {phoneNumber: '1234567890'}})
+      mocks.stubs.User.findOne.withArgs({where: {phoneNumber: 'ENCRYPTED'}})
         .returns(Promise.resolve(userObj));
 
       return userService.getUserByPhoneNumber('1234567890').should.eventually.deep.equal(userObj);
     });
 
     it('should resolve with null if no matching users were found', function() {
-      mocks.stubs.User.findOne.withArgs({where: {phoneNumber: '5555555555'}})
+      mocks.stubs.User.findOne.withArgs({where: {phoneNumber: 'ENCRYPTED'}})
         .returns(Promise.resolve(null));
 
       return userService.getUserByPhoneNumber('5555555555').should.eventually.deep.equal(null);

--- a/test/unit/userService_spec.js
+++ b/test/unit/userService_spec.js
@@ -37,11 +37,7 @@ describe('The Users Service', function() {
 
   describe('The findAll function', function() {
     it('should resolve with an array of objects representing users', function() {
-      mocks.stubs.User.findAll.returns(Promise.resolve(users.map(
-        function(user) {
-          return {dataValues: user};
-        }
-      )));
+      mocks.stubs.User.findAll.returns(Promise.resolve(users));
 
       return userService.findAll().should.eventually.deep.equal(users);
     });
@@ -56,7 +52,7 @@ describe('The Users Service', function() {
   describe('The findById function', function() {
     it('should resolve with an array with the matching user object', function() {
       mocks.stubs.User.findById.withArgs(1)
-        .returns(Promise.resolve({dataValues: users[0]}));
+        .returns(Promise.resolve(users[0]));
 
       return userService.findById(1).should.eventually.deep.equal([users[0]]);
     });
@@ -93,7 +89,7 @@ describe('The Users Service', function() {
 
     it('should resolve with an array containing the new user object', function() {
       mocks.stubs.User.create.withArgs(newUser)
-        .returns(Promise.resolve({dataValues: newUser}));
+        .returns(Promise.resolve(newUser));
 
       return userService.create(newUser).should.eventually.deep.equal([newUser]);
     });
@@ -121,7 +117,7 @@ describe('The Users Service', function() {
       mocks.stubs.User.findById.withArgs(idToUpdate)
         .returns(Promise.resolve(row));
       update.withArgs(updatedUser)
-        .returns(Promise.resolve({dataValues: updatedUser}));
+        .returns(Promise.resolve(updatedUser));
 
       return userService.update(idToUpdate, updatedUser).should.eventually.deep.equal([updatedUser]);
     });


### PR DESCRIPTION
Refactors data services to use Sequelize models correctly. Previously, we were accessing the internal `dataValues` property on the model. This prevents us from taking advantage of model features, such as adding getters and setters. It also cleans up the code considerably, and uses the API as intended.